### PR TITLE
Fix: nativescript-fonticon

### DIFF
--- a/packages/nativescript-fonticon/index.ts
+++ b/packages/nativescript-fonticon/index.ts
@@ -85,7 +85,10 @@ export class FontIconFactory {
       if (pair[1]) {
         let value = cleanValue(pair[1]);
         for (let key of keys) {
-          key = key.trim().slice(1).split(':before')[0];
+          key = key.trim()
+                  .slice(1)
+                  .split(':before')[0]
+                  .replace(/:/g, ''); // remove any extra colon characters, i.e., '::before'
           FontIconFactory.css[FontIconFactory._currentName][key] = String.fromCharCode(parseInt(value.substring(2), 16));
           if (FontIconFactory.debug) {
             mappedCss += `${key}: ${value}\n`;


### PR DESCRIPTION
Although both double colons and single colon are supported by most of Browsers. According to web standard, double colon is the right way to use pseudo selector. In recent fonticon library such as FontAwesome, they are using `::before` in their css. This make nativescript-fonticon unable to detect classname correctly. Which leading to extra colon after the key name such as `fa-info:`

This PR add:
- Support both single & double colon

Before:

![CleanShot 2024-05-05 at 12 51 23@2x](https://github.com/nstudio/nativescript-ui-kit/assets/6104383/86a31f37-6034-4b70-9c60-918e4794fd05)

After:

![CleanShot 2024-05-05 at 13 03 20@2x](https://github.com/nstudio/nativescript-ui-kit/assets/6104383/2e4f8356-0d09-4df2-b1e9-06d2908a50f4)

FontAwesome css for testing can be downloaded from: https://fontawesome.com/download


