### PR TITLE
fix: improve font icon renderer by implementing typeface caching and resolution method

### DIFF
--- a/packages/nativescript-menu/platforms/android/java/org/nativescript/menu/GlassAnchoredMenuController.java
+++ b/packages/nativescript-menu/platforms/android/java/org/nativescript/menu/GlassAnchoredMenuController.java
@@ -43,6 +43,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -117,6 +118,7 @@ public class GlassAnchoredMenuController {
 
     private final Context context;
     private final List<PopupRecord> stack = new ArrayList<>();
+    private final HashMap<String, Typeface> typefaceCache = new HashMap<>();
     private SelectionListener listener;
     private boolean notifyingDismiss;
     private View hostWindowAnchor;
@@ -780,7 +782,7 @@ public class GlassAnchoredMenuController {
         if ("font".equals(item.iconType) && !TextUtils.isEmpty(item.iconText)) {
             textIcon.setText(item.iconText);
             if (!TextUtils.isEmpty(item.iconFontFamily)) {
-                Typeface typeface = Typeface.create(item.iconFontFamily, item.iconFontWeight >= 600 ? Typeface.BOLD : Typeface.NORMAL);
+                Typeface typeface = resolveTypeface(item.iconFontFamily, item.iconFontWeight);
                 if (typeface != null) {
                     textIcon.setTypeface(typeface);
                 }
@@ -792,6 +794,72 @@ public class GlassAnchoredMenuController {
         textIcon.setTextColor(iconColor);
         textIcon.setGravity(Gravity.CENTER_VERTICAL);
         return textIcon;
+    }
+
+    private Typeface resolveTypeface(String spec, int weight) {
+        if (TextUtils.isEmpty(spec)) {
+            return null;
+        }
+
+        boolean bold = weight >= 600;
+        String cacheKey = spec + "|" + (bold ? "b" : "n");
+        Typeface cached = typefaceCache.get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+
+        Typeface typeface = null;
+        String normalized = spec.replace("\\", "/");
+        if (normalized.startsWith("~/")) {
+            normalized = normalized.substring(2);
+        }
+        if (normalized.startsWith("@/")) {
+            normalized = normalized.substring(2);
+        }
+        if (normalized.startsWith("./")) {
+            normalized = normalized.substring(2);
+        }
+        boolean looksLikeAsset = normalized.endsWith(".ttf") || normalized.endsWith(".otf") || normalized.contains("/");
+        if (looksLikeAsset) {
+            List<String> candidates = new ArrayList<>();
+            if (normalized.contains("/")) {
+                candidates.add(normalized);
+                if (normalized.startsWith("app/")) {
+                    candidates.add(normalized.substring(4));
+                } else {
+                    candidates.add("app/" + normalized);
+                }
+                if (normalized.startsWith("app/fonts/")) {
+                    candidates.add("fonts/" + normalized.substring("app/fonts/".length()));
+                }
+                if (normalized.startsWith("fonts/")) {
+                    candidates.add("app/" + normalized);
+                }
+            } else {
+                candidates.add("app/fonts/" + normalized);
+                candidates.add("fonts/" + normalized);
+                candidates.add(normalized);
+            }
+            for (String path : candidates) {
+                try {
+                    typeface = Typeface.createFromAsset(context.getAssets(), path);
+                    if (typeface != null) {
+                        break;
+                    }
+                } catch (Exception ignore) {
+                    typeface = null;
+                }
+            }
+        }
+
+        if (typeface == null) {
+            typeface = Typeface.create(normalized, bold ? Typeface.BOLD : Typeface.NORMAL);
+        }
+
+        if (typeface != null) {
+            typefaceCache.put(cacheKey, typeface);
+        }
+        return typeface;
     }
 
     private int resolveIconColor(MenuItem item) {


### PR DESCRIPTION
Hello @NathanWalker , 

I sent a few improvements, it can be perfected again if there is still something lacking.


---

## The Issue

I made a small refinement to the `Font Icon` (Issue: #40 ) usage in the `@nstudio/nativescript-menu` plugin. Although the interface is already provided by the plugin, in my testing it was not fully working as expected.

```typescript
export interface FontIcon {
    fontFamily: string;
    text: string;
    fontWeight?: number;
    color?: Color | string;
}
```

## How to Usage

After applying several fixes, the usage is now approximately as follows:

### 1. Font Icon Location
Font Icon location for each NativeScript flavors:
  - Angular: `NSPROJECT/src/app/fonts`
  - React: `NSPROJECT/src/fonts`
  - Solid: `NSPROJECT/src/fonts`
  - Svelte: `NSPROJECT/app/fonts`
  - Vue: `NSPROJECT/app/fonts`
  - Core (JS/TS): `NSPROJECT/app/fonts`

### 2. Example

Am using NativeScript Core (JS), This currenct fonts available in my project

<img width="418" height="377" alt="image" src="https://github.com/user-attachments/assets/a1b6b36c-79ac-4e24-a85b-273f82e6dd55" />

Implement Font Icon to  `@nstudio/nativescript-menu`
```javascript
const parseHexFontIcon = (hexCode) => 
  String.fromCharCode(parseInt(hexCode, 16));

context.set("addOptions", [
  // Item 1: Create Customer (FontAwesome User Plus: https://fontawesome.com/search?q=User%20plus&ic=free-collection)
  {
    id: 1,
    name: "Create Customer",
    subtitle: "Create a new customer record",
    icon: {
      // Font file name inside the fonts folder (must match exactly, including extension)
      fontFamily: "Font Awesome 7 Free-Solid-900.otf",
      // Icon hex code (f234 = user-plus)
      text: parseHexFontIcon("f234"),
      // Font weight (important for certain fonts like FontAwesome Solid)
      fontWeight: 900,
      color: "#212121",
    },
  },

  // Item 2: Sort (RemixIcon: https://remixicon.com)
  {
    id: 2,
    name: "Sort",
    subtitle: "Sort by",
    icon: {
      fontFamily: "remixicon.ttf",
      text: parseHexFontIcon("f160"), // Hex code from RemixIcon
      fontWeight: 400,
      color: "#212121",
    },
  },

  // Additional example: Settings Menu (FontAwesome Gear: https://fontawesome.com/search?q=gear&ic=free-collection)
  {
    id: 3,
    name: "Settings",
    subtitle: "Change application preferences",
    icon: {
      // Use the same font file
      fontFamily: "Font Awesome 7 Free-Solid-900.otf",
      // The 'gear' hex code is f013
      text: parseHexFontIcon("f013"),
      fontWeight: 900,
      color: "#212121",
    },
  },
]);
```

### 3. Result
<img width="301" height="235" alt="image" src="https://github.com/user-attachments/assets/78e26a2a-666f-4781-a968-50e5fe026e2e" />

